### PR TITLE
Made .isWholeNumber check for NAs

### DIFF
--- a/R/RUVg-methods.R
+++ b/R/RUVg-methods.R
@@ -1,13 +1,9 @@
-.isWholeNumber <- function(x, tol = .Machine$double.eps^0.5) {
-    abs(x - round(x)) < tol
-}
-
 setMethod(
           f = "RUVg",
           signature = signature(x="matrix", cIdx="ANY", k="numeric"),
           definition = function(x, cIdx, k, drop=0, center=TRUE, round=TRUE, epsilon=1, tolerance=1e-8, isLog=FALSE) {
             
-            if ( !all( .isWholeNumber(x) ) & !isLog ){
+            if(!isLog && !all(.isWholeNumber(x))) {
                 warning(paste0("The expression matrix does not contain counts.\n",
                                "Please, pass a matrix of counts (not logged) or set isLog to TRUE to skip the log transformation"))
             }
@@ -34,7 +30,7 @@ setMethod(
             W <- svdWa$u[, (first:k), drop = FALSE]
             alpha <- solve(t(W) %*% W) %*% t(W) %*% Y
             correctedY <- Y - W %*% alpha
-            if(!isLog & all(.isWholeNumber(x))) {
+            if(!isLog && all(.isWholeNumber(x))) {
                 if(round) {
                     correctedY <- round(exp(correctedY) - epsilon)
                     correctedY[correctedY<0] <- 0

--- a/R/RUVr-methods.R
+++ b/R/RUVr-methods.R
@@ -3,7 +3,7 @@ setMethod(
           signature = signature(x="matrix", cIdx="ANY", k="numeric", residuals="matrix"),
           definition = function(x, cIdx, k, residuals, center=TRUE, round=TRUE, epsilon=1, tolerance=1e-8, isLog=FALSE) {
 
-            if ( !all( .isWholeNumber(x) ) & !isLog ){
+            if(!isLog && !all(.isWholeNumber(x))) {
               warning(paste0("The expression matrix does not contain counts.\n",
                              "Please, pass a matrix of counts (not logged) or set isLog to TRUE to skip the log transformation"))
             }
@@ -27,7 +27,7 @@ setMethod(
             W <- svdWa$u[, (1:k), drop = FALSE]
             alpha <- solve(t(W) %*% W) %*% t(W) %*% Y
             correctedY <- Y - W %*% alpha
-            if(!isLog & all(.isWholeNumber(x))) {
+            if(!isLog && all(.isWholeNumber(x))) {
                 if(round) {
                     correctedY <- round(exp(correctedY) - epsilon)
                     correctedY[correctedY<0] <- 0

--- a/R/RUVs-methods.R
+++ b/R/RUVs-methods.R
@@ -3,7 +3,7 @@ setMethod(
           signature = signature(x="matrix", cIdx="ANY", k="numeric", scIdx="matrix"),
           definition = function(x, cIdx, k, scIdx, round=TRUE, epsilon=1, tolerance=1e-8, isLog=FALSE) {
 
-            if ( !all( .isWholeNumber(x) ) & !isLog ){
+            if(!isLog && !all(.isWholeNumber(x))) {
               warning(paste0("The expression matrix does not contain counts.\n",
                              "Please, pass a matrix of counts (not logged) or set isLog to TRUE to skip the log transformation"))
             }
@@ -39,7 +39,7 @@ setMethod(
             Wa <- W %*% a
             correctedY <- Y[1:m, ] - W[1:m, ] %*% a
 
-            if(!isLog & all(.isWholeNumber(x))) {
+            if(!isLog && all(.isWholeNumber(x))) {
                 if(round) {
                     correctedY <- round(exp(correctedY) - epsilon)
                     correctedY[correctedY<0] <- 0

--- a/R/helper.R
+++ b/R/helper.R
@@ -18,3 +18,7 @@ makeGroups <- function(xs) {
   }
   groups
 }
+
+.isWholeNumber <- function(x, tol = .Machine$double.eps^0.5) {
+    !is.na(x) & abs(x - round(x)) < tol
+}


### PR DESCRIPTION
This fixes an error with NA containing data: “missing value where TRUE/FALSE needed”

Note that this will make it accept log-counts (or log-normCounts) containing NAs.

if this makes no sense, there should be an additional check for NAs in the data that aborts with a good error message before the `!isLog && !all(.isWholeNumber(x))` check.
